### PR TITLE
feat: add Microsoft Windows System Monitor (Sysmon) preset

### DIFF
--- a/presets/index.yaml
+++ b/presets/index.yaml
@@ -13,3 +13,5 @@ presets:
     sourceType: "http"
   - source: "zeek"
     sourceType: "dns"
+  - source: "microsoft"
+    sourceType: "windows_sysmon"

--- a/presets/microsoft/windows_sysmon/README.md
+++ b/presets/microsoft/windows_sysmon/README.md
@@ -1,0 +1,126 @@
+# Microsoft Windows System Monitor Log
+
+Ingests Windows System Monitor (Sysmon) event log data (EVTX-derived JSONL) and normalizes it to OCSF gold tables for process, network, file system, DNS, and registry activity.
+
+## Input Format
+
+JSONL files produced by `pyevtx-rs` (or compatible exporters). Each line is a **double-encoded JSON string** — the outer string wraps the inner event JSON object:
+
+```json
+"{\"Event\":{\"System\":{\"EventID\":1,...},\"EventData\":{\"Image\":\"...\",\"CommandLine\":\"...\"}}}"
+```
+
+The bronze `preTransform` handles the outer string unwrapping via `try_parse_json(data::STRING)`.
+
+> **Note on EventID format:** `pyevtx-rs` emits `EventID` as a plain integer. The bronze layer uses `COALESCE` to handle both the plain-integer format (real data) and the `{"#text": N}` wrapped format (some exporters).
+
+## Data Volume Path
+
+Update the `inputs` path in `preset.yaml` to point to your Unity Catalog Volume:
+
+```yaml
+autoloader:
+  inputs:
+  - /Volumes/<catalog>/<schema>/<volume>/
+```
+
+## Event IDs Covered
+
+| Category | Event IDs | OCSF Class |
+|---|---|---|
+| Process | 1 (Create), 5 (Terminate), 6 (Driver Load), 7 (Image Load), 8 (CreateRemoteThread), 10 (ProcessAccess), 25 (Tampering) | 4007 — Process Activity |
+| Network | 3 (Connection) | 4001 — Network Activity |
+| File System | 11 (FileCreate), 15 (FileCreateStreamHash), 23 (FileDelete), 26 (FileDeleteDetected) | 1001 — File System Activity |
+| DNS | 22 (DNS Query) | 4003 — DNS Activity |
+| Registry Key | 12 (Create/Delete Key/Value), 14 (Rename) | 201001 — Registry Key Activity |
+| Registry Value | 13 (SetValue) | 201002 — Registry Value Activity |
+
+## Gold Tables
+
+### `process_activity` (OCSF class 4007)
+
+| Field | Notes |
+|---|---|
+| `class_uid` | 4007 |
+| `activity_id` / `activity_name` | 1=Launch (Ev1), 2=Terminate (Ev5), 3=Open (Ev10), 4=Inject (Ev8), 99=Other (Ev6/7/25) |
+| `process` | `{pid, file.path, cmd_line, user.name, integrity_info.level}` — primary process |
+| `parent_process` | `{pid, file.path, cmd_line, user.name}` — parent (Event 1 only) |
+| `actor.process` | Source process for injection events (Ev8/10) |
+| `target.process` | Target process for injection events (Ev8/10) |
+| `unmapped` | `rule_name`, `hashes`, `granted_access`, `call_trace`, `tamper_type`, `image_loaded`, `signed`, `signature_status` |
+
+### `network_activity` (OCSF class 4001)
+
+| Field | Notes |
+|---|---|
+| `activity_id` | 1=Open (all Event 3) |
+| `src_endpoint` | `{ip, hostname, port}` |
+| `dst_endpoint` | `{ip, hostname, port, svc_name}` |
+| `connection_info` | `{direction_id, direction, protocol_name}` — Inbound/Outbound from `Initiated` field |
+| `process` | `{pid, file.path, user.name}` — process that made the connection |
+
+### `file_system_activity` (OCSF class 1001)
+
+| Field | Notes |
+|---|---|
+| `activity_id` | 1=Create (Ev11/15), 4=Delete (Ev23/26) |
+| `file` | `{path, hashes.{md5, sha256}}` — hashes extracted from `Hashes` or `Hash` field |
+| `process` | `{pid, file.path, user.name}` |
+| `unmapped` | `creation_utc_time`, `is_executable`, `archived`, `contents` (ADS content for Ev15) |
+
+### `dns_activity` (OCSF class 4003)
+
+| Field | Notes |
+|---|---|
+| `activity_id` | 1=Query (all Event 22) |
+| `status_id` | 1=Success (QueryStatus=0), 2=Failure (non-zero status) |
+| `query` | `{hostname, type='A', type_id=1}` |
+| `answers` | Array of `{rdata}` parsed from semicolon-delimited `QueryResults` |
+| `process` | `{pid, file.path, user.name}` |
+
+### `registry_key_activity` (OCSF class 201001 — Windows extension)
+
+| Field | Notes |
+|---|---|
+| `activity_id` | 1=Create (CreateKey/CreateValue), 2=Delete (DeleteKey/DeleteValue), 5=Rename (RenameKey) |
+| `reg_key` | `{path}` — full registry path |
+| `is_persistence_target` | `true` if path contains Run key, Winlogon, or Services paths |
+| `unmapped` | `new_name` for rename events |
+
+### `registry_value_activity` (OCSF class 201002 — Windows extension)
+
+| Field | Notes |
+|---|---|
+| `activity_id` | 1=Set (all Event 13) |
+| `reg_key` | `{path}` — parent key path (extracted from `TargetObject`) |
+| `reg_value` | `{name, data}` — value name and data written |
+| `is_persistence_target` | `true` if path contains Run key, Winlogon, or Services paths |
+
+## Silver Tables
+
+Six intermediate tables produced before OCSF normalization:
+
+| Table | Event IDs |
+|---|---|
+| `windows_sysmon_process` | 1, 5, 6, 7, 8, 10, 25 |
+| `windows_sysmon_network` | 3 |
+| `windows_sysmon_file` | 11, 15, 23, 26 |
+| `windows_sysmon_dns` | 22 |
+| `windows_sysmon_registry_key` | 12, 14 |
+| `windows_sysmon_registry_value` | 13 |
+
+## Test Data
+
+Real Sysmon samples were sourced from:
+- [sbousseaden/EVTX-ATTACK-SAMPLES](https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES)
+- [Yamato-Security/hayabusa-sample-evtx](https://github.com/Yamato-Security/hayabusa-sample-evtx)
+- [NextronSystems/evtx-baseline](https://github.com/NextronSystems/evtx-baseline)
+
+Converted to JSONL with `pyevtx-rs`. Synthetic records covering all 16 target EventIDs are generated by `scripts/generate_sysmon_test_data.py` in the development project.
+
+## References
+
+- [OCSF Schema Browser](https://schema.ocsf.io)
+- [Sysmon Event ID Reference](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon)
+- [MITRE ATT&CK — Sysmon Detection](https://attack.mitre.org)
+- JIRA: FEIP-1835

--- a/presets/microsoft/windows_sysmon/preset.yaml
+++ b/presets/microsoft/windows_sysmon/preset.yaml
@@ -1,0 +1,305 @@
+author: "Alan Silva <alan.silva@databricks.com>"
+title: "Microsoft Windows System Monitor Log"
+name: windows_sysmon
+description: "Windows System Monitor (Sysmon) — Process, Network, File System, DNS, and Registry activity normalized to OCSF"
+iconURL: "https://raw.githubusercontent.com/antimatterhq/dasl-content-packs/refs/heads/main/presets/default_icon.png?raw=true"
+
+autoloader:
+  format: jsonl
+  options:
+    ignoreMissingFiles: true
+    ignoreCorruptFiles: true
+  inputs:
+  - /Volumes/acs/lw/windows-sysmon/data/
+
+bronze:
+  loadAsSingleVariant: true
+  preTransform:
+    - ["try_parse_json(data::STRING) AS event_raw"]
+    - [
+        "event_raw",
+        "try_variant_get(event_raw, '$.Event.System.TimeCreated.#attributes.SystemTime', 'timestamp') AS time",
+        "COALESCE(try_variant_get(event_raw, '$.Event.System.EventID.#text', 'int'), try_variant_get(event_raw, '$.Event.System.EventID', 'int')) AS event_id",
+        "try_variant_get(event_raw, '$.Event.System.Computer', 'string') AS computer",
+        "try_variant_get(event_raw, '$.Event.System.Channel', 'string') AS channel",
+        "try_variant_get(event_raw, '$.Event.System.Version', 'int') AS sysmon_version",
+        "CAST('microsoft' AS STRING) AS source",
+        "CAST('windows-sysmon' AS STRING) AS sourcetype",
+        "current_timestamp() AS ingest_time"
+      ]
+
+silver:
+  transform:
+  - name: windows_sysmon_process
+    filter: "event_id IN (1, 5, 6, 7, 8, 10, 25)"
+    clusterBy: ["time", "event_id"]
+    fields:
+      - {name: event_id, expr: "event_id"}
+      - {name: time, expr: "time"}
+      - {name: computer, expr: "computer"}
+      - {name: event_record_id, expr: "try_variant_get(event_raw, '$.Event.System.EventRecordID', 'bigint')"}
+      - {name: rule_name, expr: "try_variant_get(event_raw, '$.Event.EventData.RuleName', 'string')"}
+      - {name: image, expr: "try_variant_get(event_raw, '$.Event.EventData.Image', 'string')"}
+      - {name: image_loaded, expr: "try_variant_get(event_raw, '$.Event.EventData.ImageLoaded', 'string')"}
+      - {name: command_line, expr: "try_variant_get(event_raw, '$.Event.EventData.CommandLine', 'string')"}
+      - {name: process_guid, expr: "try_variant_get(event_raw, '$.Event.EventData.ProcessGuid', 'string')"}
+      - {name: process_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.ProcessId', 'int') AS INT)"}
+      - {name: current_directory, expr: "try_variant_get(event_raw, '$.Event.EventData.CurrentDirectory', 'string')"}
+      - {name: parent_image, expr: "try_variant_get(event_raw, '$.Event.EventData.ParentImage', 'string')"}
+      - {name: parent_command_line, expr: "try_variant_get(event_raw, '$.Event.EventData.ParentCommandLine', 'string')"}
+      - {name: parent_process_guid, expr: "try_variant_get(event_raw, '$.Event.EventData.ParentProcessGuid', 'string')"}
+      - {name: parent_process_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.ParentProcessId', 'int') AS INT)"}
+      - {name: parent_user, expr: "try_variant_get(event_raw, '$.Event.EventData.ParentUser', 'string')"}
+      - {name: user, expr: "try_variant_get(event_raw, '$.Event.EventData.User', 'string')"}
+      - {name: logon_id, expr: "try_variant_get(event_raw, '$.Event.EventData.LogonId', 'string')"}
+      - {name: integrity_level, expr: "try_variant_get(event_raw, '$.Event.EventData.IntegrityLevel', 'string')"}
+      - {name: hashes, expr: "try_variant_get(event_raw, '$.Event.EventData.Hashes', 'string')"}
+      - {name: signed, expr: "try_variant_get(event_raw, '$.Event.EventData.Signed', 'string')"}
+      - {name: signature, expr: "try_variant_get(event_raw, '$.Event.EventData.Signature', 'string')"}
+      - {name: signature_status, expr: "try_variant_get(event_raw, '$.Event.EventData.SignatureStatus', 'string')"}
+      - {name: source_image, expr: "try_variant_get(event_raw, '$.Event.EventData.SourceImage', 'string')"}
+      - {name: source_process_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.SourceProcessId', 'int') AS INT)"}
+      - {name: source_process_guid, expr: "COALESCE(try_variant_get(event_raw, '$.Event.EventData.SourceProcessGuid', 'string'), try_variant_get(event_raw, '$.Event.EventData.SourceProcessGUID', 'string'))"}
+      - {name: source_thread_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.SourceThreadId', 'int') AS INT)"}
+      - {name: source_user, expr: "try_variant_get(event_raw, '$.Event.EventData.SourceUser', 'string')"}
+      - {name: target_image, expr: "try_variant_get(event_raw, '$.Event.EventData.TargetImage', 'string')"}
+      - {name: target_process_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.TargetProcessId', 'int') AS INT)"}
+      - {name: target_process_guid, expr: "COALESCE(try_variant_get(event_raw, '$.Event.EventData.TargetProcessGuid', 'string'), try_variant_get(event_raw, '$.Event.EventData.TargetProcessGUID', 'string'))"}
+      - {name: target_user, expr: "try_variant_get(event_raw, '$.Event.EventData.TargetUser', 'string')"}
+      - {name: new_thread_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.NewThreadId', 'int') AS INT)"}
+      - {name: start_address, expr: "try_variant_get(event_raw, '$.Event.EventData.StartAddress', 'string')"}
+      - {name: start_module, expr: "try_variant_get(event_raw, '$.Event.EventData.StartModule', 'string')"}
+      - {name: start_function, expr: "try_variant_get(event_raw, '$.Event.EventData.StartFunction', 'string')"}
+      - {name: granted_access, expr: "try_variant_get(event_raw, '$.Event.EventData.GrantedAccess', 'string')"}
+      - {name: call_trace, expr: "try_variant_get(event_raw, '$.Event.EventData.CallTrace', 'string')"}
+      - {name: tamper_type, expr: "try_variant_get(event_raw, '$.Event.EventData.Type', 'string')"}
+      - {name: raw_data, expr: "to_json(event_raw)"}
+
+  - name: windows_sysmon_network
+    filter: "event_id = 3"
+    clusterBy: ["time"]
+    fields:
+      - {name: event_id, expr: "event_id"}
+      - {name: time, expr: "time"}
+      - {name: computer, expr: "computer"}
+      - {name: event_record_id, expr: "try_variant_get(event_raw, '$.Event.System.EventRecordID', 'bigint')"}
+      - {name: rule_name, expr: "try_variant_get(event_raw, '$.Event.EventData.RuleName', 'string')"}
+      - {name: image, expr: "try_variant_get(event_raw, '$.Event.EventData.Image', 'string')"}
+      - {name: process_guid, expr: "try_variant_get(event_raw, '$.Event.EventData.ProcessGuid', 'string')"}
+      - {name: process_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.ProcessId', 'int') AS INT)"}
+      - {name: user, expr: "try_variant_get(event_raw, '$.Event.EventData.User', 'string')"}
+      - {name: protocol, expr: "try_variant_get(event_raw, '$.Event.EventData.Protocol', 'string')"}
+      - {name: initiated, expr: "try_variant_get(event_raw, '$.Event.EventData.Initiated', 'string') = 'true'"}
+      - {name: src_ip, expr: "try_variant_get(event_raw, '$.Event.EventData.SourceIp', 'string')"}
+      - {name: src_hostname, expr: "try_variant_get(event_raw, '$.Event.EventData.SourceHostname', 'string')"}
+      - {name: src_port, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.SourcePort', 'int') AS INT)"}
+      - {name: dst_ip, expr: "try_variant_get(event_raw, '$.Event.EventData.DestinationIp', 'string')"}
+      - {name: dst_hostname, expr: "try_variant_get(event_raw, '$.Event.EventData.DestinationHostname', 'string')"}
+      - {name: dst_port, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.DestinationPort', 'int') AS INT)"}
+      - {name: dst_port_name, expr: "try_variant_get(event_raw, '$.Event.EventData.DestinationPortName', 'string')"}
+      - {name: raw_data, expr: "to_json(event_raw)"}
+
+  - name: windows_sysmon_file
+    filter: "event_id IN (11, 15, 23, 26)"
+    clusterBy: ["time", "event_id"]
+    fields:
+      - {name: event_id, expr: "event_id"}
+      - {name: time, expr: "time"}
+      - {name: computer, expr: "computer"}
+      - {name: event_record_id, expr: "try_variant_get(event_raw, '$.Event.System.EventRecordID', 'bigint')"}
+      - {name: rule_name, expr: "try_variant_get(event_raw, '$.Event.EventData.RuleName', 'string')"}
+      - {name: image, expr: "try_variant_get(event_raw, '$.Event.EventData.Image', 'string')"}
+      - {name: process_guid, expr: "try_variant_get(event_raw, '$.Event.EventData.ProcessGuid', 'string')"}
+      - {name: process_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.ProcessId', 'int') AS INT)"}
+      - {name: user, expr: "try_variant_get(event_raw, '$.Event.EventData.User', 'string')"}
+      - {name: target_filename, expr: "try_variant_get(event_raw, '$.Event.EventData.TargetFilename', 'string')"}
+      - {name: creation_utc_time, expr: "try_cast(try_variant_get(event_raw, '$.Event.EventData.CreationUtcTime', 'string') AS TIMESTAMP)"}
+      - {name: hashes, expr: "try_variant_get(event_raw, '$.Event.EventData.Hashes', 'string')"}
+      - {name: hash, expr: "try_variant_get(event_raw, '$.Event.EventData.Hash', 'string')"}
+      - {name: is_executable, expr: "try_variant_get(event_raw, '$.Event.EventData.IsExecutable', 'string') = 'true'"}
+      - {name: archived, expr: "try_variant_get(event_raw, '$.Event.EventData.Archived', 'string') = 'true'"}
+      - {name: contents, expr: "try_variant_get(event_raw, '$.Event.EventData.Contents', 'string')"}
+      - {name: raw_data, expr: "to_json(event_raw)"}
+
+  - name: windows_sysmon_dns
+    filter: "event_id = 22"
+    clusterBy: ["time"]
+    fields:
+      - {name: event_id, expr: "event_id"}
+      - {name: time, expr: "time"}
+      - {name: computer, expr: "computer"}
+      - {name: event_record_id, expr: "try_variant_get(event_raw, '$.Event.System.EventRecordID', 'bigint')"}
+      - {name: rule_name, expr: "try_variant_get(event_raw, '$.Event.EventData.RuleName', 'string')"}
+      - {name: image, expr: "try_variant_get(event_raw, '$.Event.EventData.Image', 'string')"}
+      - {name: process_guid, expr: "try_variant_get(event_raw, '$.Event.EventData.ProcessGuid', 'string')"}
+      - {name: process_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.ProcessId', 'int') AS INT)"}
+      - {name: user, expr: "try_variant_get(event_raw, '$.Event.EventData.User', 'string')"}
+      - {name: query_name, expr: "try_variant_get(event_raw, '$.Event.EventData.QueryName', 'string')"}
+      - {name: query_status, expr: "try_variant_get(event_raw, '$.Event.EventData.QueryStatus', 'string')"}
+      - {name: query_results, expr: "try_variant_get(event_raw, '$.Event.EventData.QueryResults', 'string')"}
+      - {name: raw_data, expr: "to_json(event_raw)"}
+
+  - name: windows_sysmon_registry_key
+    filter: "event_id IN (12, 14)"
+    clusterBy: ["time", "event_id"]
+    fields:
+      - {name: event_id, expr: "event_id"}
+      - {name: time, expr: "time"}
+      - {name: computer, expr: "computer"}
+      - {name: event_record_id, expr: "try_variant_get(event_raw, '$.Event.System.EventRecordID', 'bigint')"}
+      - {name: rule_name, expr: "try_variant_get(event_raw, '$.Event.EventData.RuleName', 'string')"}
+      - {name: event_type, expr: "try_variant_get(event_raw, '$.Event.EventData.EventType', 'string')"}
+      - {name: image, expr: "try_variant_get(event_raw, '$.Event.EventData.Image', 'string')"}
+      - {name: process_guid, expr: "try_variant_get(event_raw, '$.Event.EventData.ProcessGuid', 'string')"}
+      - {name: process_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.ProcessId', 'int') AS INT)"}
+      - {name: user, expr: "try_variant_get(event_raw, '$.Event.EventData.User', 'string')"}
+      - {name: target_object, expr: "try_variant_get(event_raw, '$.Event.EventData.TargetObject', 'string')"}
+      - {name: new_name, expr: "try_variant_get(event_raw, '$.Event.EventData.NewName', 'string')"}
+      - {name: raw_data, expr: "to_json(event_raw)"}
+
+  - name: windows_sysmon_registry_value
+    filter: "event_id = 13"
+    clusterBy: ["time"]
+    fields:
+      - {name: event_id, expr: "event_id"}
+      - {name: time, expr: "time"}
+      - {name: computer, expr: "computer"}
+      - {name: event_record_id, expr: "try_variant_get(event_raw, '$.Event.System.EventRecordID', 'bigint')"}
+      - {name: rule_name, expr: "try_variant_get(event_raw, '$.Event.EventData.RuleName', 'string')"}
+      - {name: event_type, expr: "try_variant_get(event_raw, '$.Event.EventData.EventType', 'string')"}
+      - {name: image, expr: "try_variant_get(event_raw, '$.Event.EventData.Image', 'string')"}
+      - {name: process_guid, expr: "try_variant_get(event_raw, '$.Event.EventData.ProcessGuid', 'string')"}
+      - {name: process_id, expr: "CAST(try_variant_get(event_raw, '$.Event.EventData.ProcessId', 'int') AS INT)"}
+      - {name: user, expr: "try_variant_get(event_raw, '$.Event.EventData.User', 'string')"}
+      - {name: target_object, expr: "try_variant_get(event_raw, '$.Event.EventData.TargetObject', 'string')"}
+      - {name: details, expr: "try_variant_get(event_raw, '$.Event.EventData.Details', 'string')"}
+      - {name: raw_data, expr: "to_json(event_raw)"}
+
+gold:
+  - name: process_activity
+    input: windows_sysmon_process
+    fields:
+      - {name: class_uid, expr: "CAST(4007 AS INT)"}
+      - {name: class_name, expr: "'Process Activity'"}
+      - {name: category_uid, expr: "CAST(4 AS INT)"}
+      - {name: category_name, expr: "'System Activity'"}
+      - {name: activity_id, expr: "CASE event_id WHEN 1 THEN 1 WHEN 5 THEN 2 WHEN 8 THEN 4 WHEN 10 THEN 3 ELSE 99 END"}
+      - {name: activity_name, expr: "CASE event_id WHEN 1 THEN 'Launch' WHEN 5 THEN 'Terminate' WHEN 8 THEN 'Inject' WHEN 10 THEN 'Open' ELSE 'Other' END"}
+      - {name: type_uid, expr: "CAST(4007 * 100 + CASE event_id WHEN 1 THEN 1 WHEN 5 THEN 2 WHEN 8 THEN 4 WHEN 10 THEN 3 ELSE 99 END AS BIGINT)"}
+      - {name: time, expr: "to_timestamp(time)"}
+      - {name: timezone_offset, expr: "CAST(0 AS INT)"}
+      - {name: status_id, expr: "CAST(1 AS INT)"}
+      - {name: status, expr: "'Success'"}
+      - {name: process, expr: "named_struct('pid', COALESCE(process_id, source_process_id), 'file', named_struct('path', COALESCE(image, source_image)), 'cmd_line', command_line, 'user', named_struct('name', COALESCE(user, source_user)), 'integrity_info', named_struct('level', integrity_level))"}
+      - {name: parent_process, expr: "named_struct('pid', parent_process_id, 'file', named_struct('path', parent_image), 'cmd_line', parent_command_line, 'user', named_struct('name', parent_user))"}
+      - {name: actor, expr: "named_struct('process', named_struct('pid', source_process_id, 'file', named_struct('path', source_image), 'user', named_struct('name', source_user)))"}
+      - {name: target, expr: "named_struct('process', named_struct('pid', target_process_id, 'file', named_struct('path', target_image), 'user', named_struct('name', target_user)))"}
+      - {name: metadata, expr: "named_struct('product', named_struct('name', 'Microsoft-Windows-Sysmon', 'vendor_name', 'Microsoft', 'log_name', 'Microsoft-Windows-Sysmon/Operational'), 'uid', CAST(event_record_id AS STRING), 'processed_time', current_timestamp())"}
+      - {name: unmapped, expr: "named_struct('rule_name', rule_name, 'hashes', hashes, 'granted_access', granted_access, 'call_trace', call_trace, 'tamper_type', tamper_type, 'logon_id', logon_id, 'new_thread_id', new_thread_id, 'start_address', start_address, 'start_module', start_module, 'start_function', start_function, 'image_loaded', image_loaded, 'signed', signed, 'signature_status', signature_status)"}
+      - {name: raw_data, expr: "raw_data"}
+
+  - name: network_activity
+    input: windows_sysmon_network
+    fields:
+      - {name: class_uid, expr: "CAST(4001 AS INT)"}
+      - {name: class_name, expr: "'Network Activity'"}
+      - {name: category_uid, expr: "CAST(4 AS INT)"}
+      - {name: category_name, expr: "'Network Activity'"}
+      - {name: activity_id, expr: "CAST(1 AS INT)"}
+      - {name: activity_name, expr: "'Open'"}
+      - {name: type_uid, expr: "CAST(400101 AS BIGINT)"}
+      - {name: time, expr: "to_timestamp(time)"}
+      - {name: timezone_offset, expr: "CAST(0 AS INT)"}
+      - {name: status_id, expr: "CAST(1 AS INT)"}
+      - {name: status, expr: "'Success'"}
+      - {name: src_endpoint, expr: "named_struct('ip', src_ip, 'hostname', src_hostname, 'port', src_port)"}
+      - {name: dst_endpoint, expr: "named_struct('ip', dst_ip, 'hostname', dst_hostname, 'port', dst_port, 'svc_name', dst_port_name)"}
+      - {name: connection_info, expr: "named_struct('direction_id', CASE WHEN initiated THEN 2 ELSE 1 END, 'direction', CASE WHEN initiated THEN 'Outbound' ELSE 'Inbound' END, 'protocol_name', protocol)"}
+      - {name: process, expr: "named_struct('pid', process_id, 'file', named_struct('path', image), 'user', named_struct('name', user))"}
+      - {name: metadata, expr: "named_struct('product', named_struct('name', 'Microsoft-Windows-Sysmon', 'vendor_name', 'Microsoft', 'log_name', 'Microsoft-Windows-Sysmon/Operational'), 'uid', CAST(event_record_id AS STRING), 'processed_time', current_timestamp())"}
+      - {name: unmapped, expr: "named_struct('rule_name', rule_name, 'process_guid', process_guid)"}
+      - {name: raw_data, expr: "raw_data"}
+
+  - name: file_system_activity
+    input: windows_sysmon_file
+    fields:
+      - {name: class_uid, expr: "CAST(1001 AS INT)"}
+      - {name: class_name, expr: "'File System Activity'"}
+      - {name: category_uid, expr: "CAST(1 AS INT)"}
+      - {name: category_name, expr: "'System Activity'"}
+      - {name: activity_id, expr: "CASE event_id WHEN 11 THEN 1 WHEN 15 THEN 1 WHEN 23 THEN 4 WHEN 26 THEN 4 ELSE 99 END"}
+      - {name: activity_name, expr: "CASE event_id WHEN 11 THEN 'Create' WHEN 15 THEN 'Create' WHEN 23 THEN 'Delete' WHEN 26 THEN 'Delete' ELSE 'Other' END"}
+      - {name: type_uid, expr: "CAST(1001 * 100 + CASE event_id WHEN 11 THEN 1 WHEN 15 THEN 1 WHEN 23 THEN 4 WHEN 26 THEN 4 ELSE 99 END AS BIGINT)"}
+      - {name: time, expr: "to_timestamp(time)"}
+      - {name: timezone_offset, expr: "CAST(0 AS INT)"}
+      - {name: status_id, expr: "CAST(1 AS INT)"}
+      - {name: status, expr: "'Success'"}
+      - {name: file, expr: "named_struct('path', target_filename, 'hashes', named_struct('md5', regexp_extract(COALESCE(hashes, hash, ''), 'MD5=([A-F0-9a-f]+)', 1), 'sha256', regexp_extract(COALESCE(hashes, hash, ''), 'SHA256=([A-F0-9a-f]+)', 1)))"}
+      - {name: process, expr: "named_struct('pid', process_id, 'file', named_struct('path', image), 'user', named_struct('name', user))"}
+      - {name: metadata, expr: "named_struct('product', named_struct('name', 'Microsoft-Windows-Sysmon', 'vendor_name', 'Microsoft', 'log_name', 'Microsoft-Windows-Sysmon/Operational'), 'uid', CAST(event_record_id AS STRING), 'processed_time', current_timestamp())"}
+      - {name: unmapped, expr: "named_struct('rule_name', rule_name, 'creation_utc_time', creation_utc_time, 'is_executable', is_executable, 'archived', archived, 'contents', contents)"}
+      - {name: raw_data, expr: "raw_data"}
+
+  - name: dns_activity
+    input: windows_sysmon_dns
+    fields:
+      - {name: class_uid, expr: "CAST(4003 AS INT)"}
+      - {name: class_name, expr: "'DNS Activity'"}
+      - {name: category_uid, expr: "CAST(4 AS INT)"}
+      - {name: category_name, expr: "'Network Activity'"}
+      - {name: activity_id, expr: "CAST(1 AS INT)"}
+      - {name: activity_name, expr: "'Query'"}
+      - {name: type_uid, expr: "CAST(400301 AS BIGINT)"}
+      - {name: time, expr: "to_timestamp(time)"}
+      - {name: timezone_offset, expr: "CAST(0 AS INT)"}
+      - {name: status_id, expr: "CASE WHEN query_status = '0' THEN 1 WHEN query_status IS NOT NULL THEN 2 ELSE 0 END"}
+      - {name: status, expr: "CASE WHEN query_status = '0' THEN 'Success' WHEN query_status IS NOT NULL THEN 'Failure' ELSE 'Unknown' END"}
+      - {name: query, expr: "named_struct('hostname', query_name, 'type', 'A', 'type_id', 1)"}
+      - {name: answers, expr: "CASE WHEN query_results IS NOT NULL AND query_results != '' THEN transform(filter(split(query_results, ';'), x -> trim(x) != ''), x -> named_struct('rdata', trim(x))) ELSE array() END"}
+      - {name: process, expr: "named_struct('pid', process_id, 'file', named_struct('path', image), 'user', named_struct('name', user))"}
+      - {name: metadata, expr: "named_struct('product', named_struct('name', 'Microsoft-Windows-Sysmon', 'vendor_name', 'Microsoft', 'log_name', 'Microsoft-Windows-Sysmon/Operational'), 'uid', CAST(event_record_id AS STRING), 'processed_time', current_timestamp())"}
+      - {name: unmapped, expr: "named_struct('rule_name', rule_name, 'query_status', query_status)"}
+      - {name: raw_data, expr: "raw_data"}
+
+  - name: registry_key_activity
+    input: windows_sysmon_registry_key
+    fields:
+      - {name: class_uid, expr: "CAST(201001 AS INT)"}
+      - {name: class_name, expr: "'Registry Key Activity'"}
+      - {name: category_uid, expr: "CAST(201 AS INT)"}
+      - {name: category_name, expr: "'Windows Registry'"}
+      - {name: activity_id, expr: "CASE event_type WHEN 'CreateKey' THEN 1 WHEN 'DeleteKey' THEN 2 WHEN 'CreateValue' THEN 1 WHEN 'DeleteValue' THEN 2 WHEN 'RenameKey' THEN 5 ELSE 99 END"}
+      - {name: activity_name, expr: "CASE event_type WHEN 'CreateKey' THEN 'Create' WHEN 'DeleteKey' THEN 'Delete' WHEN 'CreateValue' THEN 'Create' WHEN 'DeleteValue' THEN 'Delete' WHEN 'RenameKey' THEN 'Rename' ELSE 'Other' END"}
+      - {name: type_uid, expr: "CAST(201001 * 100 + CASE event_type WHEN 'CreateKey' THEN 1 WHEN 'DeleteKey' THEN 2 WHEN 'CreateValue' THEN 1 WHEN 'DeleteValue' THEN 2 WHEN 'RenameKey' THEN 5 ELSE 99 END AS BIGINT)"}
+      - {name: time, expr: "to_timestamp(time)"}
+      - {name: timezone_offset, expr: "CAST(0 AS INT)"}
+      - {name: status_id, expr: "CAST(1 AS INT)"}
+      - {name: status, expr: "'Success'"}
+      - {name: reg_key, expr: "named_struct('path', target_object)"}
+      - {name: process, expr: "named_struct('pid', process_id, 'file', named_struct('path', image), 'user', named_struct('name', user))"}
+      - {name: is_persistence_target, expr: "target_object LIKE '%CurrentVersion%Run%' OR target_object LIKE '%Winlogon%' OR target_object LIKE '%SYSTEM%Services%'"}
+      - {name: metadata, expr: "named_struct('product', named_struct('name', 'Microsoft-Windows-Sysmon', 'vendor_name', 'Microsoft', 'log_name', 'Microsoft-Windows-Sysmon/Operational'), 'uid', CAST(event_record_id AS STRING), 'processed_time', current_timestamp())"}
+      - {name: unmapped, expr: "named_struct('rule_name', rule_name, 'new_name', new_name)"}
+      - {name: raw_data, expr: "raw_data"}
+
+  - name: registry_value_activity
+    input: windows_sysmon_registry_value
+    fields:
+      - {name: class_uid, expr: "CAST(201002 AS INT)"}
+      - {name: class_name, expr: "'Registry Value Activity'"}
+      - {name: category_uid, expr: "CAST(201 AS INT)"}
+      - {name: category_name, expr: "'Windows Registry'"}
+      - {name: activity_id, expr: "CAST(1 AS INT)"}
+      - {name: activity_name, expr: "'Set'"}
+      - {name: type_uid, expr: "CAST(20100201 AS BIGINT)"}
+      - {name: time, expr: "to_timestamp(time)"}
+      - {name: timezone_offset, expr: "CAST(0 AS INT)"}
+      - {name: status_id, expr: "CAST(1 AS INT)"}
+      - {name: status, expr: "'Success'"}
+      - {name: reg_key, expr: "named_struct('path', regexp_extract(COALESCE(target_object, ''), '^(.*)[\\\\\\\\][^\\\\\\\\]+$', 1))"}
+      - {name: reg_value, expr: "named_struct('name', regexp_extract(COALESCE(target_object, ''), '[^\\\\\\\\]+$', 0), 'data', details)"}
+      - {name: process, expr: "named_struct('pid', process_id, 'file', named_struct('path', image), 'user', named_struct('name', user))"}
+      - {name: is_persistence_target, expr: "target_object LIKE '%CurrentVersion%Run%' OR target_object LIKE '%Winlogon%' OR target_object LIKE '%SYSTEM%Services%'"}
+      - {name: metadata, expr: "named_struct('product', named_struct('name', 'Microsoft-Windows-Sysmon', 'vendor_name', 'Microsoft', 'log_name', 'Microsoft-Windows-Sysmon/Operational'), 'uid', CAST(event_record_id AS STRING), 'processed_time', current_timestamp())"}
+      - {name: unmapped, expr: "named_struct('rule_name', rule_name)"}
+      - {name: raw_data, expr: "raw_data"}

--- a/presets/microsoft/windows_sysmon/version.yaml
+++ b/presets/microsoft/windows_sysmon/version.yaml
@@ -1,0 +1,2 @@
+version: "1.0.0"
+min_lakewatch_version: "0.1.0"


### PR DESCRIPTION
## Summary

- Adds new preset `presets/microsoft/windows_sysmon/` for ingesting Windows System Monitor (Sysmon) event logs (EVTX-derived JSONL)
- Normalizes to 6 OCSF gold tables covering process, network, file system, DNS, and registry activity
- Covers 16 Sysmon EventIDs across all major telemetry categories
- Updates `presets/index.yaml` with `source: microsoft / sourceType: windows_sysmon`

## Technical notes

- **Input format:** Double-encoded JSONL from `pyevtx-rs` — bronze uses `try_parse_json(data::STRING)` to unwrap
- **EventID format:** `pyevtx-rs` emits `EventID` as a plain integer; bronze uses `COALESCE` to handle both plain-int and `{"#text": N}` wrapped formats
- **EventData extraction:** Flat key-value dict (`$.Event.EventData.FieldName`) — unlike Security EVTX which uses a `Data` array
- **Registry split:** Event 12/14 → `registry_key_activity` (201001); Event 13 → `registry_value_activity` (201002)
- **`is_persistence_target`:** Boolean flag on registry tables for Run key / Winlogon / Services paths

## Event IDs

| Gold table | OCSF class | Event IDs |
|---|---|---|
| `process_activity` | 4007 | 1, 5, 6, 7, 8, 10, 25 |
| `network_activity` | 4001 | 3 |
| `file_system_activity` | 1001 | 11, 15, 23, 26 |
| `dns_activity` | 4003 | 22 |
| `registry_key_activity` | 201001 | 12, 14 |
| `registry_value_activity` | 201002 | 13 |

## Test data

Validated against 6,700+ real Sysmon records from:
- [sbousseaden/EVTX-ATTACK-SAMPLES](https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES)
- [Yamato-Security/hayabusa-sample-evtx](https://github.com/Yamato-Security/hayabusa-sample-evtx)
- [NextronSystems/evtx-baseline](https://github.com/NextronSystems/evtx-baseline)